### PR TITLE
Fix preset saving by specifying cartridge type in build param

### DIFF
--- a/Source/Makefile
+++ b/Source/Makefile
@@ -15,7 +15,7 @@ build:
 
 	$(BIN)/gbdk-n-link.sh $(OBJ)/mgb.rel $(OBJ)/mgb_save.rel $(OBJ)/mGBASMFunctions.rel $(OBJ)/mGBASMSynthFunctions.rel $(OBJ)/mGBASMMidiFunctions.rel -o $(OBJ)/mgb.ihx
 
-	$(BIN)/gbdk-n-make-rom.sh -ya 1 $(OBJ)/mgb.ihx mgb.gb
+	$(BIN)/gbdk-n-make-rom.sh -yt 3 -ya 1 $(OBJ)/mgb.ihx mgb.gb
 
 clean:
 	rm -rf $(OBJ)


### PR DESCRIPTION
This option will set the cartridge type as `ROM+MBC1+RAM+BATT ` which is needed for presets to save properly and persist a reboot:

See: https://github.com/darconeous/sdcc/blob/master/support/makebin/makebin.c#L129-L143